### PR TITLE
fix appending and prepending } and whitespace in directivePattern

### DIFF
--- a/src/chordpro.js
+++ b/src/chordpro.js
@@ -14,7 +14,7 @@ module.exports = {
   parse: function (chordProStr) {
     var commentPattern = /^\s*#.*/;
     var chordPattern = /\[([^\]]*)\]/;
-    var directivePattern = /([\w]*):(.*)/;
+    var directivePattern = /([\w]*):\s*(.*[A-z])(?=[\}\s]*$)/;
     var sectionHeadPattern = /^([A-z0-9\s]+):(\s*)$/;
     var song = new Song();
     var section = song.createSection();


### PR DESCRIPTION
I saw your pull request in [tvdavies repo](https://github.com/tvdavies/chordprojs/pull/2) 
The original chordpro format wants `{` and `}` around `title` (see [here](https://www.chordpro.org/chordpro/ChordPro-File-Format-Specification.html)

I made them optional, now both solutions work, like
```
{title: Swing Low Sweet Chariot}
OR
title: Swing Low Sweet Chariot
```
and removed unnecessary whitespaces at the beginning and end. 


_BTW: love the transpose feature _🙈
